### PR TITLE
fix: remove mock env from production builds

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -5,8 +5,8 @@ import { retrieveLaunchParams } from '@telegram-apps/sdk-react';
 import { init } from './core/init';
 import { mockEnv } from './mockEnv';
 
-mockEnv()
-  .then(() => {
+mockEnv().then(() => {
+  try {
     const launchParams = retrieveLaunchParams();
     const { tgWebAppPlatform: platform } = launchParams;
     const debug =
@@ -18,6 +18,8 @@ mockEnv()
       debug,
       eruda: debug && ['ios', 'android'].includes(platform),
       mockForMacOS: platform === 'macos',
-    }).catch(console.error);
-  })
-  .catch(console.error);
+    });
+  } catch (e) {
+    console.log(e);
+  }
+});

--- a/src/mockEnv.ts
+++ b/src/mockEnv.ts
@@ -1,78 +1,83 @@
 import { mockTelegramEnv, isTMA, emitEvent } from '@telegram-apps/sdk-react';
 
-export async function mockEnv() {
-  if (!(await isTMA('complete'))) {
-    const themeParams = {
-      accent_text_color: '#6ab2f2',
-      bg_color: '#17212b',
-      button_color: '#5288c1',
-      button_text_color: '#ffffff',
-      destructive_text_color: '#ec3942',
-      header_bg_color: '#17212b',
-      hint_color: '#708499',
-      link_color: '#6ab3f3',
-      secondary_bg_color: '#232e3c',
-      section_bg_color: '#17212b',
-      section_header_text_color: '#6ab3f3',
-      subtitle_text_color: '#708499',
-      text_color: '#f5f5f5',
-    } as const;
-    const noInsets = { left: 0, top: 0, bottom: 0, right: 0 } as const;
-
-    mockTelegramEnv({
-      onEvent(e) {
-        // Here you can write your own handlers for all known Telegram MIni Apps methods.
-        if (e[0] === 'web_app_request_theme') {
-          return emitEvent('theme_changed', { theme_params: themeParams });
-        }
-        if (e[0] === 'web_app_request_viewport') {
-          return emitEvent('viewport_changed', {
-            height: window.innerHeight,
-            width: window.innerWidth,
-            is_expanded: true,
-            is_state_stable: true,
-          });
-        }
-        if (e[0] === 'web_app_request_content_safe_area') {
-          return emitEvent('content_safe_area_changed', noInsets);
-        }
-        if (e[0] === 'web_app_request_safe_area') {
-          return emitEvent('safe_area_changed', noInsets);
-        }
-      },
-      launchParams: new URLSearchParams([
-        // Discover more launch parameters:
-        // https://docs.telegram-mini-apps.com/platform/launch-parameters#parameters-list
-        ['tgWebAppThemeParams', JSON.stringify(themeParams)],
-        // Your init data goes here. Learn more about it here:
-        // https://docs.telegram-mini-apps.com/platform/init-data#parameters-list
-        //
-        // Note that to make sure, you are using a valid init data, you must pass it exactly as it
-        // is sent from the Telegram application. The reason is in case you will sort its keys
-        // (auth_date, hash, user, etc.) or values your own way, init data validation will more
-        // likely to fail on your server side. So, to make sure you are working with a valid init
-        // data, it is better to take a real one from your application and paste it here. It should
-        // look something like this (a correctly encoded URL search params):
-        // ```
-        // user=%7B%22id%22%3A279058397%2C%22first_name%22%3A%22Vladislav%22%2C%22last_name%22...
-        // ```
-        // But in case you don't really need a valid init data, use this one:
-        [
-          'tgWebAppData',
-          new URLSearchParams([
-            ['auth_date', ((new Date().getTime() / 1000) | 0).toString()],
-            ['hash', 'some-hash'],
-            ['signature', 'some-signature'],
-            ['user', JSON.stringify({ id: 1, first_name: 'Vladislav' })],
-          ]).toString(),
-        ],
-        ['tgWebAppVersion', '8.4'],
-        ['tgWebAppPlatform', 'tdesktop'],
-      ]),
+// It is important, to mock the environment only for development purposes. When building the
+// application, the code inside will be tree-shaken, so you will not see it in your final bundle.
+export async function mockEnv(): Promise<void> {
+  if (process.env.NODE_ENV === "development") {
+    return isTMA('complete').then((isTma) => {
+      if (!isTma){ 
+        const themeParams = {
+          accent_text_color: '#6ab2f2',
+          bg_color: '#17212b',
+          button_color: '#5288c1',
+          button_text_color: '#ffffff',
+          destructive_text_color: '#ec3942',
+          header_bg_color: '#17212b',
+          hint_color: '#708499',
+          link_color: '#6ab3f3',
+          secondary_bg_color: '#232e3c',
+          section_bg_color: '#17212b',
+          section_header_text_color: '#6ab3f3',
+          subtitle_text_color: '#708499',
+          text_color: '#f5f5f5',
+        } as const;
+        const noInsets = { left: 0, top: 0, bottom: 0, right: 0 } as const;
+    
+        mockTelegramEnv({
+          onEvent(e) {
+            // Here you can write your own handlers for all known Telegram Mini Apps methods.
+            if (e[0] === 'web_app_request_theme') {
+              return emitEvent('theme_changed', { theme_params: themeParams });
+            }
+            if (e[0] === 'web_app_request_viewport') {
+              return emitEvent('viewport_changed', {
+                height: window.innerHeight,
+                width: window.innerWidth,
+                is_expanded: true,
+                is_state_stable: true,
+              });
+            }
+            if (e[0] === 'web_app_request_content_safe_area') {
+              return emitEvent('content_safe_area_changed', noInsets);
+            }
+            if (e[0] === 'web_app_request_safe_area') {
+              return emitEvent('safe_area_changed', noInsets);
+            }
+          },
+          launchParams: new URLSearchParams([
+            // Discover more launch parameters:
+            // https://docs.telegram-mini-apps.com/platform/launch-parameters#parameters-list
+            ['tgWebAppThemeParams', JSON.stringify(themeParams)],
+            // Your init data goes here. Learn more about it here:
+            // https://docs.telegram-mini-apps.com/platform/init-data#parameters-list
+            //
+            // Note that to make sure, you are using a valid init data, you must pass it exactly as it
+            // is sent from the Telegram application. The reason is in case you will sort its keys
+            // (auth_date, hash, user, etc.) or values your own way, init data validation will more
+            // likely to fail on your server side. So, to make sure you are working with a valid init
+            // data, it is better to take a real one from your application and paste it here. It should
+            // look something like this (a correctly encoded URL search params):
+            // ```
+            // user=%7B%22id%22%3A279058397%2C%22first_name%22%3A%22Vladislav%22%2C%22last_name%22...
+            // ```
+            // But in case you don't really need a valid init data, use this one:
+            ['tgWebAppData', new URLSearchParams([
+              ['auth_date', (new Date().getTime() / 1000 | 0).toString()],
+              ['hash', 'some-hash'],
+              ['signature', 'some-signature'],
+              ['user', JSON.stringify({ id: 1, first_name: 'Vladislav' })],
+            ]).toString()],
+            ['tgWebAppVersion', '8.4'],
+            ['tgWebAppPlatform', 'tdesktop'],
+          ]),
+        });
+    
+        console.info(
+          '⚠️ As long as the current environment was not considered as the Telegram-based one, it was mocked. Take a note, that you should not do it in production and current behavior is only specific to the development process. Environment mocking is also applied only in development mode. So, after building the application, you will not see this behavior and related warning, leading to crashing the application outside Telegram.',
+        );
+      }
     });
+  }  
 
-    console.info(
-      '⚠️ As long as the current environment was not considered as the Telegram-based one, it was mocked. Take a note, that you should not do it in production and current behavior is only specific to the development process. Environment mocking is also applied only in development mode. So, after building the application, you will not see this behavior and related warning, leading to crashing the application outside Telegram.',
-    );
-  }
+  return Promise.resolve();
 }

--- a/src/mockEnv.ts
+++ b/src/mockEnv.ts
@@ -3,81 +3,79 @@ import { mockTelegramEnv, isTMA, emitEvent } from '@telegram-apps/sdk-react';
 // It is important, to mock the environment only for development purposes. When building the
 // application, the code inside will be tree-shaken, so you will not see it in your final bundle.
 export async function mockEnv(): Promise<void> {
-  if (process.env.NODE_ENV === "development") {
-    return isTMA('complete').then((isTma) => {
-      if (!isTma){ 
-        const themeParams = {
-          accent_text_color: '#6ab2f2',
-          bg_color: '#17212b',
-          button_color: '#5288c1',
-          button_text_color: '#ffffff',
-          destructive_text_color: '#ec3942',
-          header_bg_color: '#17212b',
-          hint_color: '#708499',
-          link_color: '#6ab3f3',
-          secondary_bg_color: '#232e3c',
-          section_bg_color: '#17212b',
-          section_header_text_color: '#6ab3f3',
-          subtitle_text_color: '#708499',
-          text_color: '#f5f5f5',
-        } as const;
-        const noInsets = { left: 0, top: 0, bottom: 0, right: 0 } as const;
-    
-        mockTelegramEnv({
-          onEvent(e) {
-            // Here you can write your own handlers for all known Telegram Mini Apps methods.
-            if (e[0] === 'web_app_request_theme') {
-              return emitEvent('theme_changed', { theme_params: themeParams });
-            }
-            if (e[0] === 'web_app_request_viewport') {
-              return emitEvent('viewport_changed', {
-                height: window.innerHeight,
-                width: window.innerWidth,
-                is_expanded: true,
-                is_state_stable: true,
-              });
-            }
-            if (e[0] === 'web_app_request_content_safe_area') {
-              return emitEvent('content_safe_area_changed', noInsets);
-            }
-            if (e[0] === 'web_app_request_safe_area') {
-              return emitEvent('safe_area_changed', noInsets);
-            }
-          },
-          launchParams: new URLSearchParams([
-            // Discover more launch parameters:
-            // https://docs.telegram-mini-apps.com/platform/launch-parameters#parameters-list
-            ['tgWebAppThemeParams', JSON.stringify(themeParams)],
-            // Your init data goes here. Learn more about it here:
-            // https://docs.telegram-mini-apps.com/platform/init-data#parameters-list
-            //
-            // Note that to make sure, you are using a valid init data, you must pass it exactly as it
-            // is sent from the Telegram application. The reason is in case you will sort its keys
-            // (auth_date, hash, user, etc.) or values your own way, init data validation will more
-            // likely to fail on your server side. So, to make sure you are working with a valid init
-            // data, it is better to take a real one from your application and paste it here. It should
-            // look something like this (a correctly encoded URL search params):
-            // ```
-            // user=%7B%22id%22%3A279058397%2C%22first_name%22%3A%22Vladislav%22%2C%22last_name%22...
-            // ```
-            // But in case you don't really need a valid init data, use this one:
-            ['tgWebAppData', new URLSearchParams([
-              ['auth_date', (new Date().getTime() / 1000 | 0).toString()],
-              ['hash', 'some-hash'],
-              ['signature', 'some-signature'],
-              ['user', JSON.stringify({ id: 1, first_name: 'Vladislav' })],
-            ]).toString()],
-            ['tgWebAppVersion', '8.4'],
-            ['tgWebAppPlatform', 'tdesktop'],
-          ]),
-        });
-    
-        console.info(
-          '⚠️ As long as the current environment was not considered as the Telegram-based one, it was mocked. Take a note, that you should not do it in production and current behavior is only specific to the development process. Environment mocking is also applied only in development mode. So, after building the application, you will not see this behavior and related warning, leading to crashing the application outside Telegram.',
-        );
-      }
-    });
-  }  
-
-  return Promise.resolve();
+  return process.env.NODE_ENV !== 'development'
+  ? undefined
+  : isTMA('complete').then((isTma) => {
+    if (!isTma){ 
+      const themeParams = {
+        accent_text_color: '#6ab2f2',
+        bg_color: '#17212b',
+        button_color: '#5288c1',
+        button_text_color: '#ffffff',
+        destructive_text_color: '#ec3942',
+        header_bg_color: '#17212b',
+        hint_color: '#708499',
+        link_color: '#6ab3f3',
+        secondary_bg_color: '#232e3c',
+        section_bg_color: '#17212b',
+        section_header_text_color: '#6ab3f3',
+        subtitle_text_color: '#708499',
+        text_color: '#f5f5f5',
+      } as const;
+      const noInsets = { left: 0, top: 0, bottom: 0, right: 0 } as const;
+  
+      mockTelegramEnv({
+        onEvent(e) {
+          // Here you can write your own handlers for all known Telegram Mini Apps methods.
+          if (e[0] === 'web_app_request_theme') {
+            return emitEvent('theme_changed', { theme_params: themeParams });
+          }
+          if (e[0] === 'web_app_request_viewport') {
+            return emitEvent('viewport_changed', {
+              height: window.innerHeight,
+              width: window.innerWidth,
+              is_expanded: true,
+              is_state_stable: true,
+            });
+          }
+          if (e[0] === 'web_app_request_content_safe_area') {
+            return emitEvent('content_safe_area_changed', noInsets);
+          }
+          if (e[0] === 'web_app_request_safe_area') {
+            return emitEvent('safe_area_changed', noInsets);
+          }
+        },
+        launchParams: new URLSearchParams([
+          // Discover more launch parameters:
+          // https://docs.telegram-mini-apps.com/platform/launch-parameters#parameters-list
+          ['tgWebAppThemeParams', JSON.stringify(themeParams)],
+          // Your init data goes here. Learn more about it here:
+          // https://docs.telegram-mini-apps.com/platform/init-data#parameters-list
+          //
+          // Note that to make sure, you are using a valid init data, you must pass it exactly as it
+          // is sent from the Telegram application. The reason is in case you will sort its keys
+          // (auth_date, hash, user, etc.) or values your own way, init data validation will more
+          // likely to fail on your server side. So, to make sure you are working with a valid init
+          // data, it is better to take a real one from your application and paste it here. It should
+          // look something like this (a correctly encoded URL search params):
+          // ```
+          // user=%7B%22id%22%3A279058397%2C%22first_name%22%3A%22Vladislav%22%2C%22last_name%22...
+          // ```
+          // But in case you don't really need a valid init data, use this one:
+          ['tgWebAppData', new URLSearchParams([
+            ['auth_date', (new Date().getTime() / 1000 | 0).toString()],
+            ['hash', 'some-hash'],
+            ['signature', 'some-signature'],
+            ['user', JSON.stringify({ id: 1, first_name: 'Vladislav' })],
+          ]).toString()],
+          ['tgWebAppVersion', '8.4'],
+          ['tgWebAppPlatform', 'tdesktop'],
+        ]),
+      });
+  
+      console.info(
+        '⚠️ As long as the current environment was not considered as the Telegram-based one, it was mocked. Take a note, that you should not do it in production and current behavior is only specific to the development process. Environment mocking is also applied only in development mode. So, after building the application, you will not see this behavior and related warning, leading to crashing the application outside Telegram.',
+      );
+    }
+  });
 }


### PR DESCRIPTION
Add `process.env.NODE_ENV === "development"` check to avoid having mocked environment in production builds.